### PR TITLE
Cliu/input length restriction

### DIFF
--- a/react/src/components/CaptionForm/index.js
+++ b/react/src/components/CaptionForm/index.js
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
+import { Form, Input } from 'antd';
 import { useSelector, useDispatch } from 'react-redux'
 import "./caption.css"
+import { MAX_CAPTION_LEN, MAX_CREDIT_LEN } from "constants/formInput"
+
+const { TextArea } = Input
 
 // helper component
 function CaptionImagePair(props){
@@ -57,11 +61,22 @@ function CaptionImagePair(props){
     <div className="image-caption-row">
         <img className="caption-image" src={props.img_url}/>
         <div>
-            <h4>Caption: </h4>
-            <textarea value={caption} onChange={e => updateStateAndReduxCaption(e.target.value)}/>
-
-            <h4>Credit: </h4>
-            <textarea value={credit} onChange={e => updateStateAndReduxCredit(e.target.value)}/>
+            <Form.Item label="Caption">
+                <TextArea
+                    maxLength={MAX_CAPTION_LEN}
+                    showCount
+                    value={caption}
+                    onChange={e => updateStateAndReduxCaption(e.target.value)}
+                />
+            </Form.Item>
+            <Form.Item label="Credit">
+                <TextArea
+                    maxLength={MAX_CREDIT_LEN}
+                    showCount
+                    value={credit}
+                    onChange={e => updateStateAndReduxCredit(e.target.value)}
+                />
+            </Form.Item>
         </div>
     </div>
    )

--- a/react/src/components/GalleryBasicInfo/index.js
+++ b/react/src/components/GalleryBasicInfo/index.js
@@ -3,6 +3,8 @@ import { Form, Input, Select } from 'antd';
 import { useSelector, useDispatch } from 'react-redux';
 import { PageHeader } from 'antd';
 
+import { MAX_NAME_LEN, MAX_DESCR_LEN } from "constants/formInput"
+
 const { Option } = Select;
 const { TextArea } = Input;
 
@@ -71,10 +73,10 @@ function GalleryBasicInfo() {
 		    }}
 	    	>
 	      <Form.Item name="name" label="Name" rules={[{ required: true }]}>
-	        <Input maxLength={50} />
+	        <Input maxLength={MAX_NAME_LEN} />
 	      </Form.Item>
 	      <Form.Item name="description" label="Description" rules={[{ required: true }]}>
-	        <TextArea maxLength={200} showCount />
+	        <TextArea maxLength={MAX_DESCR_LEN} showCount />
 	      </Form.Item>
 	      <Form.Item name="layout" label="Layout Style" rules={[{ required: true }]}>
 	        <Select

--- a/react/src/components/GalleryBasicInfo/index.js
+++ b/react/src/components/GalleryBasicInfo/index.js
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import { Form, Input, Button, Select } from 'antd';
+import React from 'react';
+import { Form, Input, Select } from 'antd';
 import { useSelector, useDispatch } from 'react-redux';
 import { PageHeader } from 'antd';
 
@@ -10,9 +10,6 @@ const layout = {
   labelCol: { span: 2 },
   wrapperCol: { span: 8 },
 };
-
-
-
 
 
 function GalleryBasicInfo() {

--- a/react/src/components/GalleryBasicInfo/index.js
+++ b/react/src/components/GalleryBasicInfo/index.js
@@ -74,10 +74,10 @@ function GalleryBasicInfo() {
 		    }}
 	    	>
 	      <Form.Item name="name" label="Name" rules={[{ required: true }]}>
-	        <Input />
+	        <Input maxLength={50} />
 	      </Form.Item>
 	      <Form.Item name="description" label="Description" rules={[{ required: true }]}>
-	        <TextArea />
+	        <TextArea maxLength={200} showCount />
 	      </Form.Item>
 	      <Form.Item name="layout" label="Layout Style" rules={[{ required: true }]}>
 	        <Select

--- a/react/src/constants/formInput.js
+++ b/react/src/constants/formInput.js
@@ -1,4 +1,4 @@
-export const MAX_NAME_LEN = 50;
-export const MAX_DESCR_LEN = 200;
-export const MAX_CAPTION_LEN = 200;
-export const MAX_CREDIT_LEN = 200;
+export const MAX_NAME_LEN = 100;
+export const MAX_DESCR_LEN = 100;
+export const MAX_CAPTION_LEN = 300;
+export const MAX_CREDIT_LEN = 50;

--- a/react/src/constants/formInput.js
+++ b/react/src/constants/formInput.js
@@ -1,0 +1,4 @@
+export const MAX_NAME_LEN = 50;
+export const MAX_DESCR_LEN = 200;
+export const MAX_CAPTION_LEN = 200;
+export const MAX_CREDIT_LEN = 200;


### PR DESCRIPTION
Add input length restrictions for name, description, caption, and credits fields using antd's built-in maxLength props. Length limits are defined in constants/formInput.js. 